### PR TITLE
v1.5.1 - Tracker changes:

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ By default the BatchEventPool is configured to use one thread (worker), you can 
 These are the default parameters for both Classes (inside config.py):
 ```python
 # Tracker Config
-BATCH_SIZE = 500
+BATCH_SIZE = 64
 BATCH_BYTES_SIZE = 64 * 1024
 # Default flush interval in millisecodns
 FLUSH_INTERVAL = 10000
@@ -38,12 +38,12 @@ FLUSH_INTERVAL = 10000
 # Batch Event Pool Config
 # Default Number of workers(threads) for BatchEventPool
 BATCH_WORKER_COUNT = 1
-# Default Number of events to hold in BatchEventPool
-BATCH_POOL_SIZE = 3000
+# Default Number of batch events to hold in BatchEventPool
+BATCH_POOL_SIZE = 1
 
 # EventStorage Config (backlog)
 # Default backlog queue size (per stream)
-BACKLOG_SIZE = 12000
+BACKLOG_SIZE = 500
 
 # Retry on 500 / Connection error conf
 # Retry max time in seconds
@@ -204,6 +204,13 @@ api.put_events(stream=stream, data=data, auth_key=auth2)
 
 ## Change Log
 
+### v1.5.1
+- Tracker changes:
+    - bug fix: replaced dequeue with Queue.Queuq on Backlog & BatchEventPool.  
+      dequeue caused excessive consumption of memory and cpu.  
+      Note that .track() is now blocking when backlog is full
+    - Changed defaults for Backlog & BatchEventPool
+    
 ### v1.5.0
 - Tracker changes:
     - Added periodical flush function and changed the interval mechanism

--- a/README.md
+++ b/README.md
@@ -206,10 +206,12 @@ api.put_events(stream=stream, data=data, auth_key=auth2)
 
 ### v1.5.1
 - Tracker changes:
-    - bug fix: replaced dequeue with Queue.Queuq on Backlog & BatchEventPool.  
+    - bug fix: replaced dequeue with Queue.Queue on Backlog & BatchEventPool.  
       dequeue caused excessive consumption of memory and cpu.  
       Note that .track() is now blocking when backlog is full
     - Changed defaults for Backlog & BatchEventPool
+    - bug fix: fixing a case of negative timer when executing after sleep
+    - bug fix: fixing a bug in the tracker handler when there are no tracked events (busy waiting)
     
 ### v1.5.0
 - Tracker changes:

--- a/ironsource/__init__.py
+++ b/ironsource/__init__.py
@@ -1,4 +1,4 @@
 __author__ = 'g8y3e'
-__version__ = '1.5.0'
+__version__ = '1.5.1'
 __license__ = 'MIT'
 __copyright__ = "ironSource"

--- a/ironsource/atom/config.py
+++ b/ironsource/atom/config.py
@@ -1,10 +1,10 @@
 # Atom Python SDK config file
 
-SDK_VERSION = "1.5.0"
+SDK_VERSION = "1.5.1"
 ATOM_ENDPOINT = "http://track.atom-data.io/"
 
 # Tracker Config
-BATCH_SIZE = 500
+BATCH_SIZE = 64
 BATCH_BYTES_SIZE = 64 * 1024
 
 # Default flush interval in millisecodns
@@ -13,12 +13,12 @@ FLUSH_INTERVAL = 10000
 # Batch Event Pool Config
 # Default Number of workers(threads) for BatchEventPool
 BATCH_WORKER_COUNT = 1
-# Default Number of events to hold in BatchEventPool
-BATCH_POOL_SIZE = 3000
+# Default Number of batch events to hold in BatchEventPool
+BATCH_POOL_SIZE = 1
 
 # EventStorage Config (backlog)
 # Default backlog queue size (per stream)
-BACKLOG_SIZE = 12000
+BACKLOG_SIZE = 500
 
 # Retry on 500 / Connection error conf
 

--- a/ironsource/atom/ironsource_atom_tracker.py
+++ b/ironsource/atom/ironsource_atom_tracker.py
@@ -68,6 +68,8 @@ class IronSourceAtomTracker:
 
         # Init Atom basic SDK
         self._is_debug = is_debug
+        # For debug printing
+        self._debug_counter = 0
         self._atom = IronSourceAtom(endpoint=endpoint, is_debug=self._is_debug, auth_key=auth_key)
         self._logger = logger.get_logger(debug=self._is_debug)
 
@@ -195,6 +197,7 @@ class IronSourceAtomTracker:
             if stream not in self._stream_keys:
                 self._stream_keys[stream] = auth_key
             self._event_backlog.add_event(Event(stream, data))
+            self._debug_counter += 1
 
     def flush(self):
         """
@@ -291,9 +294,12 @@ class IronSourceAtomTracker:
             # Status 200 - OK or 400 - Client Error
             if 200 <= response.status < 500:
                 if 200 <= response.status < 400:
-                    self._logger.info('Status: {}; Response: {}; Error: {}'.format(str(response.status),
-                                                                                   str(response.data),
-                                                                                   str(response.error)))
+                    if self._debug_counter >= 1000:
+                        self._logger.info('Tracked 1000 events')
+                        self._logger.info('Status: {}; Response: {}; Error: {}'.format(str(response.status),
+                                                                                       str(response.data),
+                                                                                       str(response.error)))
+                        self._debug_counter = 0
                 else:
                     # 400
                     self._error_log(attempt, time.time(), response.status, response.error, data)

--- a/ironsource/atom/ironsource_atom_tracker.py
+++ b/ironsource/atom/ironsource_atom_tracker.py
@@ -13,6 +13,7 @@ import random
 
 from threading import Lock
 from threading import Thread
+from threading import Timer
 
 
 class IronSourceAtomTracker:
@@ -223,8 +224,13 @@ class IronSourceAtomTracker:
             if i % 2 == 0:
                 self._logger.debug("Flushing In {} Seconds".format(next_call - time.time()))
             i += 1
-            time.sleep(next_call - time.time())
-            self.flush()
+            try:
+                time.sleep(next_call - time.time())
+                self.flush()
+            except (IOError, ValueError) as e:
+                # Can happen after sleep
+                self._logger.error("Timer error: {}".format(str(e.args)))
+                next_call = time.time()
 
     def _tracker_handler(self):
         """

--- a/ironsource/atom/ironsource_atom_tracker.py
+++ b/ironsource/atom/ironsource_atom_tracker.py
@@ -13,7 +13,6 @@ import random
 
 from threading import Lock
 from threading import Thread
-from threading import Timer
 
 
 class IronSourceAtomTracker:

--- a/ironsource_example/example.py
+++ b/ironsource_example/example.py
@@ -105,3 +105,4 @@ if __name__ == "__main__":
         thread.join()
 
     print ("Finished all example methods.")
+    time.sleep(1000000)

--- a/ironsource_example/example.py
+++ b/ironsource_example/example.py
@@ -62,8 +62,8 @@ if __name__ == "__main__":
     api_tracker = IronSourceAtomTracker(flush_interval=10000,
                                         callback=callback_func,
                                         batch_bytes_size=64000,
-                                        batch_size=100,
-                                        is_debug=True,
+                                        batch_size=64,
+                                        is_debug=False,
                                         endpoint=endpoint)
 
 
@@ -73,19 +73,20 @@ if __name__ == "__main__":
             self._thread_lock = Lock()
 
         def thread_worker(self, args):
+            print("[EXAMPLE] Thread {} started".format(args))
 
             while True:
                 with self._thread_lock:
                     self._call_index += 1
                     data_track = {"id": self._call_index, "event_name": "PYTHON_SDK_TRACKER_EXAMPLE",
                                   "string_value": str(random.random())}
-                    # exit after 40
+                    # exit after 100
                     if self._call_index >= 100:
                         return
                     else:
                         # Track every odd event with delay
                         if self._call_index % 10 == 0:
-                            time.sleep(3)
+                            time.sleep(1)
                             print("[EXAMPLE] Tracking Data")
                     api_tracker.track(stream=stream, data=data_track, auth_key=auth_key)
 
@@ -103,5 +104,4 @@ if __name__ == "__main__":
     for thread in threads_array:
         thread.join()
 
-    time.sleep(10000)
     print ("Finished all example methods.")


### PR DESCRIPTION
- bug fix: replaced dequeue with Queue.Queuq on Backlog & BatchEventPool.
  dequeue caused excessive consumption of memory and cpu.
  Note that .track() is now blocking when backlog is full
- Changed defaults for Backlog & BatchEventPool