### PR TITLE
V1.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ To specify path use: `debug_file_path` (defaults to /tmp/)
 The logging will produce JSON files with request and response objects.  
 Each request-response pair will have a unique id.  
 Logging file name is: atom-raw.{month}-{day}.json  
-The file will log-rotate at 10MB and save up to 100 files, based on: RotatingFileHandler at Python Logging module.
+The file will log-rotate at 50MB and save up to 100 files, based on: RotatingFileHandler at Python Logging module.
 
 ### Abstract class for storing data at tracker backlog `EventStorage`
 If you'd like to customize the tracker backlog, implement the following abstract class.
@@ -245,9 +245,10 @@ api.put_events(stream=stream, data=data, auth_key=auth2)
 ## Change Log
 
 ### v1.5.4
-- Added support for logging all requests and responses to file
+- Added support for logging of all requests and responses to file
 - BugFix: Graceful shutdown did not stop the tracker completely while there are requests in flight and server-error.
 - Added raw 'requests' lib response to the Response class.
+- Added top limits to tracker conf
 
 ### v1.5.3
 - Added timeout to GET and POST (default 60 seconds)

--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ These are the default parameters for both Classes (inside config.py):
 
 ```python
 # Tracker Config
-BATCH_SIZE = 64
+BATCH_SIZE = 256
+BATCH_SIZE_LIMIT = 2000
 BATCH_BYTES_SIZE = 64 * 1024
-
-# Default flush interval in millisecodns
+BATCH_BYTES_SIZE_LIMIT = 512 * 1024
+# Default flush interval in milliseconds
 FLUSH_INTERVAL = 10000
 
 # Batch Event Pool Config
@@ -69,6 +70,12 @@ RETRY_FOREVER = True
 BACKLOG_BLOCKING = True
 # Tracker backlog Queue GET & PUT timeout in seconds (ignored if backlog is blocking)
 BACKLOG_TIMEOUT = 1
+
+# HTTP requests lib session GET/POST timeout in seconds (default: 60 seconds)
+REQUEST_TIMEOUT = 60
+
+# Debug file path once debug_to_file is enabled
+DEBUG_FILE_PATH = "/tmp/"
 
 # Init a new tracker:
 tracker = IronSourceAtomTracker(batch_worker_count=config.BATCH_WORKER_COUNT,
@@ -98,7 +105,7 @@ tracker = IronSourceAtomTracker(batch_worker_count=config.BATCH_WORKER_COUNT,
 :param flush_interval:     Optional, Tracker flush interval in milliseconds (default 10000)
 :param retry_max_time:     Optional, Retry max time in seconds
 :param retry_max_count:    Optional, Maximum number of retries in seconds
-:param batch_size:         Optional, Amount of events in every batch (bulk) (default: 500)
+:param batch_size:         Optional, Amount of events in every batch (bulk) (default: 256)
 :param batch_bytes_size:   Optional, Size of each batch (bulk) in bytes (default: 64KB)
 :param is_debug:           Optional, Enable printing of debug information
 :param debug_to_file:      Optional, Should the Tracker write the request and response objects to file
@@ -216,15 +223,16 @@ The Low Level SDK has 2 methods:
 from ironsource.atom.ironsource_atom import IronSourceAtom
 
 auth = "DEFAULT_AUTH_KEY"
-api = IronSourceAtom(is_debug=False, endpoint=config.ATOM_URL, auth_key=auth, request_timeout=60)
+api = IronSourceAtom(is_debug=False, endpoint=config.ATOM_ENDPOINT, auth_key="", request_timeout=60,
+                     debug_to_file=False, debug_file_path=config.DEBUG_FILE_PATH)
 """
 Atom class init function
 :param is_debug:            Optional, Enable/Disable debug
 :param endpoint:            Optional, Atom API Endpoint
 :param auth_key:            Optional, Atom auth key
 :param request_timeout:     Optional, request timeout (default: 60)
-:param debug_to_file:      Optional, Should the Tracker write the request and response objects to file
-:param debug_file_path:    Optional, the path to the debug file (debug_to_file must be True) (default: /tmp)
+:param debug_to_file:       Optional, Should the Tracker write the request and response objects to file (default: False)
+:param debug_file_path:     Optional, the path to the debug file (debug_to_file must be True) (default: /tmp)
 """
 # Note: If you don't specify an auth key, then it would use the default (if you set it with set_auth)
 # Else it won't use any.

--- a/README.md
+++ b/README.md
@@ -139,17 +139,17 @@ tracker.flush()
 tracker.stop()
 ```
 ### Logging of request/response to file (since version 1.5.4)
-**Note: this is recommended only if you want to debug the SDK**  
+**Note:** this is recommended only if you want to debug the SDK  
 To enable use: `debug_to_file` parameter at the tracker construction  
-To specify path use: `debug_file_path` (default to /tmp)  
+To specify path use: `debug_file_path` (defaults to /tmp/)  
 The logging will produce JSON files with request and response objects.  
 Each request-response pair will have a unique id.  
 Logging file name is: atom-raw.{month}-{day}.json  
-The file will log-rotate at 10MB and save up to 100 files. using: RotatingFileHandler at Python Logging module.
+The file will log-rotate at 10MB and save up to 100 files, based on: RotatingFileHandler at Python Logging module.
 
 ### Abstract class for storing data at tracker backlog `EventStorage`
 If you'd like to customize the tracker backlog, implement the following abstract class.
-Implementation must to be synchronized for multithreading use.
+Implementation must to be synchronized for multi threading use.
 ```python
 import abc
 
@@ -246,7 +246,7 @@ api.put_events(stream=stream, data=data, auth_key=auth2)
 
 ### v1.5.4
 - Added support for logging all requests and responses to file
-- BugFix: Graceful shutdown did not stop the tracker completely while there are requests in flight and retrying.
+- BugFix: Graceful shutdown did not stop the tracker completely while there are requests in flight and server-error.
 - Added raw 'requests' lib response to the Response class.
 
 ### v1.5.3

--- a/ironsource/__init__.py
+++ b/ironsource/__init__.py
@@ -1,4 +1,4 @@
 __author__ = 'Atom Core Team'
-__version__ = '1.5.3'
+__version__ = '1.5.4'
 __license__ = 'MIT'
 __copyright__ = "ironSource"

--- a/ironsource/atom/atom_logger.py
+++ b/ironsource/atom/atom_logger.py
@@ -16,7 +16,7 @@ def get_logger(name="AtomLogger", debug=False, file_name="atom-raw.json"):
         logger.setLevel(logging.INFO)
         ch = logging.handlers.RotatingFileHandler(file_name,
                                                   encoding="utf8",
-                                                  maxBytes=10 * 1024 * 1024,
+                                                  maxBytes=50 * 1024 * 1024,
                                                   backupCount=100)
         ch.setLevel(logging.INFO)
         logger.addHandler(ch)

--- a/ironsource/atom/atom_logger.py
+++ b/ironsource/atom/atom_logger.py
@@ -1,15 +1,27 @@
 import logging
+import logging.handlers
 
 
-def get_logger(name="AtomLogger", debug=False):
+def get_logger(name="AtomLogger", debug=False, file_name="atom-raw.json"):
     """
-    Atom Logger
+    Atom Logger factory: If AtomRawLogger == name then it will return a rotating-file logger, else just logs to stdout.
     :param name: logger name
     :param debug: Disable/enable debug printing
     :return:
     """
     logger = logging.getLogger(name)
     new_level = logging.DEBUG if debug else logging.INFO
+
+    if name == "AtomRawLogger":
+        logger.setLevel(logging.INFO)
+        ch = logging.handlers.RotatingFileHandler(file_name,
+                                                  encoding="utf8",
+                                                  maxBytes=10 * 1024 * 1024,
+                                                  backupCount=100)
+        ch.setLevel(logging.INFO)
+        logger.addHandler(ch)
+        logger.propagate = 0
+        return logger
 
     if logger.level == logging.NOTSET or logger.level != new_level:
         logger.setLevel(new_level)

--- a/ironsource/atom/config.py
+++ b/ironsource/atom/config.py
@@ -38,3 +38,6 @@ BACKLOG_TIMEOUT = 1
 
 # HTTP requests lib session GET/POST timeout in seconds (default: 60 seconds)
 REQUEST_TIMEOUT = 60
+
+# Debug file path once debug_to_file is enabled
+DEBUG_FILE_PATH = "/tmp/"

--- a/ironsource/atom/config.py
+++ b/ironsource/atom/config.py
@@ -1,12 +1,13 @@
 # Atom Python SDK config file
 
-SDK_VERSION = "1.5.3"
+SDK_VERSION = "1.5.4"
 ATOM_ENDPOINT = "http://track.atom-data.io/"
 
 # Tracker Config
-BATCH_SIZE = 64
+BATCH_SIZE = 256
+BATCH_SIZE_LIMIT = 2000
 BATCH_BYTES_SIZE = 64 * 1024
-
+BATCH_BYTES_SIZE_LIMIT = 512 * 1024
 # Default flush interval in milliseconds
 FLUSH_INTERVAL = 10000
 

--- a/ironsource/atom/ironsource_atom.py
+++ b/ironsource/atom/ironsource_atom.py
@@ -1,7 +1,6 @@
 import json
 import hmac
 import datetime
-import time
 import requests
 import hashlib
 import ironsource.atom.atom_logger as logger

--- a/ironsource/atom/ironsource_atom.py
+++ b/ironsource/atom/ironsource_atom.py
@@ -1,10 +1,14 @@
 import json
 import hmac
+import datetime
+import time
 import requests
 import hashlib
 import ironsource.atom.atom_logger as logger
 from ironsource.atom.request import Request
 import ironsource.atom.config as config
+import uuid
+import os
 
 
 class IronSourceAtom:
@@ -14,7 +18,9 @@ class IronSourceAtom:
 
     TAG = "IronSourceAtom"
 
-    def __init__(self, is_debug=False, endpoint=config.ATOM_ENDPOINT, auth_key="", request_timeout=60):
+    def __init__(self, is_debug=False, endpoint=config.ATOM_ENDPOINT, auth_key="", request_timeout=60,
+                 debug_to_file=False,
+                 debug_file_path=config.DEBUG_FILE_PATH):
         """
         Atom class init function
 
@@ -26,6 +32,10 @@ class IronSourceAtom:
         :type  auth_key:            str
         :param request_timeout:     Optional, request timeout (default: 60)
         :type  request_timeout:     int
+        :param debug_to_file:       Optional, Should the Tracker write the request and response objects to file
+        :type  debug_to_file:       bool
+        :param debug_file_path:     Optional, the path to the debug file (debug_to_file must be True) (default: /tmp)
+        :type  debug_file_path:     str
 
         """
 
@@ -42,6 +52,18 @@ class IronSourceAtom:
 
         # init logger
         self._logger = logger.get_logger(debug=self._is_debug)
+
+        self._debug_to_file = debug_to_file
+        if self._debug_to_file:
+            if os.path.isdir(debug_file_path) and os.access(debug_file_path, os.W_OK | os.R_OK):
+                self._debug_file_path = debug_file_path
+            else:
+                self._debug_file_path = config.DEBUG_FILE_PATH
+                self._logger.error("No Read & Write access to the supplied log file path, setting default: {}"
+                                   .format(config.DEBUG_FILE_PATH))
+            now = datetime.datetime.now()
+            log_file_name = self._debug_file_path + "atom-raw.{day}-{month}.json".format(day=now.day, month=now.month)
+            self._raw_logger = logger.get_logger(name="AtomRawLogger", file_name=log_file_name)
 
     def set_debug(self, is_debug):  # pragma: no cover
         """
@@ -82,10 +104,13 @@ class IronSourceAtom:
         if len(auth_key) == 0:
             auth_key = self._auth_key
 
+        request_time = datetime.datetime.now().isoformat()
         request_data = self.create_request_data(stream, auth_key, data)
-
-        return self.send_data(url=self._endpoint, data=request_data, method=method,
-                              headers=self._headers, timeout=self._timeout)
+        response = self.send_data(url=self._endpoint, data=request_data, method=method, headers=self._headers,
+                                  timeout=self._timeout)
+        if self._debug_to_file:
+            self._session_to_file(response, request_time)
+        return response
 
     def put_events(self, stream, data, auth_key=""):
         """Send multiple events (batch) to Atom API
@@ -112,8 +137,12 @@ class IronSourceAtom:
         data = json.dumps(data)
         request_data = self.create_request_data(stream, auth_key, data, batch=True)
 
-        return self.send_data(url=self._endpoint + "bulk", data=request_data, method="post",
-                              headers=self._headers, timeout=self._timeout)
+        request_time = datetime.datetime.now().isoformat()
+        response = self.send_data(url=self._endpoint + "bulk", data=request_data, method="post", headers=self._headers,
+                                  timeout=self._timeout)
+        if self._debug_to_file:
+            self._session_to_file(response, request_time)
+        return response
 
     @staticmethod
     def create_request_data(stream, auth_key, data, batch=False):
@@ -172,3 +201,39 @@ class IronSourceAtom:
                 return request.get()
             else:
                 return request.post()
+
+    def _session_to_file(self, response, request_time):
+        """
+        Writes SDK request and response to JSON file in the following format:
+        [{req},{res}...]
+        :param request_time: request time
+        :param response: The 'requests' lib response object (including the original request)
+        """
+        raw_request = response.raw_response.request
+        request_data = raw_request.body if raw_request.body is not None else '"{}"'.format(raw_request.path_url)
+        session_id = uuid.uuid4()
+        # self._raw_logger.emit("hi")
+        self._raw_logger.info('''{"request": {"id": "%s", "requestTime": "%s", "data": %s, "headers": %s}}''' %
+                              (session_id,
+                               request_time,
+                               request_data,
+                               json.dumps(str(raw_request.headers))
+                               ))
+        # Format response
+        response_headers = json.dumps(str(response.raw_response.headers)) \
+            if hasattr(response.raw_response, "headers") else "\"None\""
+        response_body = response.data if response.data is not None else response.error
+        try:
+            response_body = json.loads(response_body)
+        except ValueError:
+            pass
+        # There is no consistency at API response on v1
+        if response.status == 401:
+            response_body = str(response_body).replace("\"", "'")
+        self._raw_logger.info(
+            '''{"response": {"id": "%s", "responseTime": "%s", "body": "%s", "code": %s, "headers": %s}}''' %
+            (session_id,
+             datetime.datetime.now().isoformat(),
+             response_body,
+             response.status,
+             response_headers))

--- a/ironsource/atom/ironsource_atom_tracker.py
+++ b/ironsource/atom/ironsource_atom_tracker.py
@@ -124,22 +124,25 @@ class IronSourceAtomTracker:
         self._retry_max_count = retry_max_count
 
         # Batch size
-        if not isinstance(batch_size, int) or batch_size < 1:
-            self._logger.warning("Batch Size must be 1 or greater! Setting default: {}"
-                                 .format(config.BATCH_SIZE))
+        if not isinstance(batch_size, int) or batch_size < 1 or batch_size > config.BATCH_SIZE_LIMIT:
+            self._logger.warning("Invalid Bulk size, must between 1 to {max}, setting it to {default}"
+                                 .format(max=config.BATCH_SIZE_LIMIT, default=config.BATCH_SIZE))
             batch_size = config.BATCH_SIZE
         self._batch_size = batch_size
 
         # Batch bytes size
-        if not isinstance(batch_bytes_size, int) or batch_bytes_size < 1:
-            self._logger.warning("Batch Bytes Size must be 1 or greater! Setting default: {}"
-                                 .format(config.BATCH_BYTES_SIZE))
+        if not isinstance(batch_bytes_size, int) \
+                or batch_bytes_size < 1024 \
+                or batch_bytes_size > config.BATCH_BYTES_SIZE_LIMIT:
+            self._logger.warning("Invalid Bulk byte size, must between 1KB to {max}KB, setting it to {default}KB"
+                                 .format(max=config.BATCH_BYTES_SIZE_LIMIT / 1024,
+                                         default=config.BATCH_BYTES_SIZE / 1024))
             batch_bytes_size = config.BATCH_BYTES_SIZE
         self._batch_bytes_size = batch_bytes_size
 
         # Flush Interval
         if not isinstance(flush_interval, int) or flush_interval < 1000:
-            self._logger.warning("Flush Interval must be 1000 or greater! Setting default: {}"
+            self._logger.warning("Flush Interval must be 1000ms or greater! Setting default: {}"
                                  .format(config.FLUSH_INTERVAL))
             flush_interval = config.FLUSH_INTERVAL
         self._flush_interval = flush_interval

--- a/ironsource/atom/request.py
+++ b/ironsource/atom/request.py
@@ -39,14 +39,16 @@ class Request:
 
         try:
             response = self._session.get(self._url, params=params, timeout=self._timeout)
-        except requests.exceptions.ConnectionError:  # pragma: no cover
-            return Response("No connection to server", None, 500)
+        except requests.exceptions.ConnectionError as ex:  # pragma: no cover
+            response = ex
+            return Response("No connection to server", None, 500, response)
         except requests.exceptions.RequestException as ex:  # pragma: no cover
-            return Response(ex, None, 400)
+            response = ex
+            return Response(ex, None, 400, response)
         if 200 <= response.status_code < 400:
-            return Response(None, response.content, response.status_code)
+            return Response(None, response.content, response.status_code, response)
         else:
-            return Response(response.content, None, response.status_code)
+            return Response(response.content, None, response.status_code, response)
 
     def post(self):
         """
@@ -60,12 +62,14 @@ class Request:
         """
         try:
             response = self._session.post(url=self._url, data=self._data, timeout=self._timeout)
-        except requests.exceptions.ConnectionError:  # pragma: no cover
-            return Response("No connection to server", None, 500)
+        except requests.exceptions.ConnectionError as ex:  # pragma: no cover
+            response = ex
+            return Response("No connection to server", None, 500, response)
         except requests.exceptions.RequestException as ex:  # pragma: no cover
-            return Response(ex, None, 400)
+            response = ex
+            return Response(ex, None, 400, response)
 
         if 200 <= response.status_code < 400:
-            return Response(None, response.content, response.status_code)
+            return Response(None, response.content, response.status_code, response)
         else:
-            return Response(response.content, None, response.status_code)
+            return Response(response.content, None, response.status_code, response)

--- a/ironsource/atom/response.py
+++ b/ironsource/atom/response.py
@@ -1,16 +1,20 @@
 class Response:
     """
-        Response information from server
+        Response information from Atom server
+    """
 
+    def __init__(self, error, data, status, raw_response):
+        """
         :param error: Error information
         :type error: object
         :param data: Response information data
         :type data: object
         :param status: Response status from server
         :type status: int
-    """
-
-    def __init__(self, error, data, status):
+        :param raw_response: Original response object
+        :type raw_response: object
+        """
         self.error = error
         self.data = data
         self.status = status
+        self.raw_response = raw_response

--- a/ironsource_example/example.py
+++ b/ironsource_example/example.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import json
 import random
 from ironsource.atom.ironsource_atom import IronSourceAtom
@@ -64,6 +65,8 @@ if __name__ == "__main__":
                                         batch_bytes_size=64000,
                                         batch_size=64,
                                         is_debug=True,
+                                        debug_to_file=True,
+                                        debug_file_path="./",
                                         endpoint=endpoint)
 
 
@@ -79,7 +82,9 @@ if __name__ == "__main__":
                 with self._thread_lock:
                     self._call_index += 1
                     data_track = {"id": self._call_index, "event_name": "PYTHON_SDK_TRACKER_EXAMPLE",
-                                  "string_value": str(random.random())}
+                                  "string_value": str(random.random()),
+                                  "non_ascii": "Lista de leitura, novos recursos de privacidade e segurança, "
+                                               "além de mais velocidade Esses são os atrativos do novo Safari"}
                     # exit after 100
                     if self._call_index >= 100:
                         return

--- a/ironsource_example/example.py
+++ b/ironsource_example/example.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     endpoint = "http://track.atom-data.io/"
     api_tracker = IronSourceAtomTracker(flush_interval=10000,
                                         callback=callback_func,
-                                        batch_bytes_size=64000,
+                                        batch_bytes_size=64 * 1024,
                                         batch_size=64,
                                         is_debug=True,
                                         debug_to_file=True,


### PR DESCRIPTION
### v1.5.4
- Added support for logging of all requests and responses to file.
- BugFix: Graceful shutdown did not stop the tracker completely while there are requests in flight and server-error.
- Added raw 'requests' lib response to the Response class.
- Added top limits to tracker conf.